### PR TITLE
#64 Add insert blocks for country and city data to load_schema_and_data.p…

### DIFF
--- a/schema/insert.sql
+++ b/schema/insert.sql
@@ -1,4 +1,0 @@
-copy botanist(email, name, phone)
-from '.schema/seed_botanists.csv'
-delimiter ','
-csv header;

--- a/schema/load_schema_and_data.py
+++ b/schema/load_schema_and_data.py
@@ -5,23 +5,48 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def get_connection():
+    return pymssql.connect(server=os.getenv('DB_HOST'), port=int(os.getenv('DB_PORT', 1433)),
+                           user=os.getenv('DB_USER'), password=os.getenv('DB_PASSWORD'),
+                           database=os.getenv('DB_NAME'))
+
+
 if __name__ == "__main__":
-    conn = pymssql.connect(server=os.getenv('DB_HOST'), port=int(os.getenv('DB_PORT', 1433)),
-                          user=os.getenv('DB_USER'), password=os.getenv('DB_PASSWORD'),
-                          database=os.getenv('DB_NAME'))
-    cursor = conn.cursor()
+    conn = get_connection()
+    with conn.cursor() as cursor:
+        with open('schema.sql') as f:
+            for stmt in f.read().split(';'):
+                if stmt.strip():
+                    cursor.execute(stmt)
+                    conn.commit()
 
-    with open('schema.sql') as f:
-        for stmt in f.read().split(';'):
-            if stmt.strip():
-                cursor.execute(stmt)
+    with conn.cursor() as cursor:
+        with open('seed_botanists.csv') as f:
+            for row in csv.DictReader(f):
+                cursor.execute("INSERT INTO botanist (email, name, phone) VALUES (%s, %s, %s)",
+                               (row['botanist_email'], row['botanist_name'], row['botanist_phone']))
+                conn.commit()
 
-    with open('seed_botanists.csv') as f:
-        for row in csv.DictReader(f):
-            cursor.execute("INSERT INTO botanist (email, name, phone) VALUES (%s, %s, %s)",
-                         (row['botanist_email'], row['botanist_name'], row['botanist_phone']))
+    with conn.cursor() as cursor:
+        cursor.execute("SET IDENTITY_INSERT country ON")
+        with open('countries.csv') as f:
+            for row in csv.DictReader(f):
+                cursor.execute("INSERT INTO country (country_name, country_id) VALUES (%s, %s)",
+                               (row['origin_country'], row['country_id']))
+                conn.commit()
+        cursor.execute("SET IDENTITY_INSERT country OFF")
+        conn.commit()
 
-    conn.commit()
-    cursor.close()
+    with conn.cursor() as cursor:
+        cursor.execute("SET IDENTITY_INSERT city ON")
+        with open('cities.csv') as f:
+            for row in csv.DictReader(f):
+                cursor.execute("INSERT INTO city (city_name, city_id, country_id) VALUES (%s, %s, %s)",
+                               (row['origin_city'], row['city_id'], row['country_id']))
+                conn.commit()
+        cursor.execute("SET IDENTITY_INSERT city OFF")
+        conn.commit()
+
     conn.close()
     print("Schema and data loaded successfully.")


### PR DESCRIPTION
Addresses #64 by adding to load and insert to db script. Insert.sql file has been removed as redundant. The new code includes turning on off the automatic generation of primary key ids. Requires a cities.csv and countries.csv which can be generated by running the associated transform script.