### PR TITLE
I added a routine adter export_to_parquet.py to wipe all data in RDS …

### DIFF
--- a/rds_s3_pipeline/export_to_parquet.py
+++ b/rds_s3_pipeline/export_to_parquet.py
@@ -120,8 +120,28 @@ def export_all_tables():
     conn.close()
     print("\n✓ Export complete!")
 
+def delete_old_plant_readings():
+    """Delete plant_reading records older than 24 hours from the database."""
+    print("\n[INFO] Starting deletion of old plant_reading records...")
+    delete_query = """
+        DELETE FROM plant_reading
+        WHERE recording_taken < DATEADD(hour, -24, GETDATE())
+    """
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(delete_query)
+    deleted_count = cursor.rowcount
+    conn.commit()
+    cursor.close()
+    conn.close()
+    print(f"[INFO] Deleted {deleted_count} plant_reading records older than 24 hours.")
+
 def handler(event, context):
+    print("[INFO] Starting table export from RDS to S3...")
     export_all_tables()
+    print("[INFO] Export complete. Proceeding to delete old plant_reading records...")
+    delete_old_plant_readings()
+    print("[INFO] Data export and cleanup finished.")
 
 if __name__ == "__main__":
     export_all_tables()


### PR DESCRIPTION
I added a routine adter export_to_parquet.py to wipe all data in RDS older than 24 hours. This is meant to happen right after the script pulls the data from the RDS to the s3 bucket.